### PR TITLE
chore: widen Node engine constraint to >=24 to allow Node 26+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"typescript": "^6.0.3"
 			},
 			"engines": {
-				"node": "^24.0.0"
+				"node": ">=24.0.0"
 			}
 		},
 		"node_modules/@astrojs/check": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"type": "module",
 	"engines": {
-		"node": "^24.0.0"
+		"node": ">=24.0.0"
 	},
 	"scripts": {
 		"dev": "astro dev",


### PR DESCRIPTION
## What

Widen the `engines.node` constraint in `package.json` (and the mirrored field in `package-lock.json`) from `^24.0.0` to `>=24.0.0`.

## Why

The project sets `engine-strict=true` in `.npmrc`, which makes npm **hard-fail** on an engine mismatch rather than warn. The previous `^24.0.0` constraint only permits Node 24.x, so `npm install` aborted with `EBADENGINE` on Node 26:

```
npm error code EBADENGINE
npm error Required: {"node":"^24.0.0"}
npm error Actual:   {"node":"v26.4.0","npm":"11.17.0"}
```

Widening to `>=24.0.0` allows Node 24 and newer while still blocking anything below 24.

## Notes

- No dependency or source changes — purely the engine constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)