### PR TITLE
Add security headers (Cloudflare + Vercel) with a forward-compatible CSP

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,8 +1,9 @@
 # Security headers for Cloudflare Pages.
 # https://developers.cloudflare.com/pages/configuration/headers/
 # This file is copied verbatim into dist/ at build time and applied by the
-# Cloudflare Pages edge. (Note: it is NOT applied by `astro preview`, and Vercel
-# previews ignore it — Vercel uses vercel.json.)
+# Cloudflare Pages edge. (Note: it is NOT applied by `astro preview`.) Vercel
+# does not read _headers — vercel.json mirrors these headers for Vercel, and a
+# test (tests/test.spec.js) asserts the two stay identical so they can't drift.
 #
 # Content-Security-Policy philosophy: lock down the high-risk directive
 # (script-src) and stay permissive on the directives that commonly change as the

--- a/public/_headers
+++ b/public/_headers
@@ -4,17 +4,24 @@
 # Cloudflare Pages edge. (Note: it is NOT applied by `astro preview`, and Vercel
 # previews ignore it — Vercel uses vercel.json.)
 #
-# The Content-Security-Policy below is tailored to exactly what the site loads:
-#   - default-src 'self'              everything same-origin unless listed
-#   - img-src ... res.cloudinary.com  the fixed background photo (favicon/og are same-origin)
-#   - style-src 'unsafe-inline'       Astro inlines scoped <style>, plus the honeypot style="" attr
-#   - script-src 'self'               no runtime JS; the JSON-LD block is non-executable
-#   - form-action ... formspree.io    the contact form POSTs to Formspree
-# If you add an analytics script, web font, or other origin, widen the matching
-# directive or the browser will block it.
+# Content-Security-Policy philosophy: lock down the high-risk directive
+# (script-src) and stay permissive on the directives that commonly change as the
+# site grows, so adding pages/images/fonts/styles doesn't silently break.
+#   - script-src 'self'   only first-party JS runs. Astro bundles framework
+#                         islands (React/Svelte/etc.) as same-origin module
+#                         scripts, so 'self' already covers them. A *third-party*
+#                         script (analytics, a CDN) would need its origin added
+#                         here — and tests/test.spec.js will fail loudly if a page
+#                         ever loads something this policy blocks.
+#   - img/style/font      allow any https: source (+ data:) so new images, web
+#                         fonts, or inline styles Just Work.
+#   - connect-src 'self'  same-origin fetch/XHR only. If you add client-side
+#                         calls to a third-party API, widen this (the page-load
+#                         test can't catch runtime fetches).
+#   - form-action         the contact form posts to Formspree.
 
 /*
-  Content-Security-Policy: default-src 'self'; img-src 'self' https://res.cloudinary.com; style-src 'self' 'unsafe-inline'; script-src 'self'; font-src 'self'; form-action https://formspree.io; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; img-src 'self' https: data:; style-src 'self' 'unsafe-inline' https:; script-src 'self'; font-src 'self' https: data:; connect-src 'self'; form-action 'self' https://formspree.io; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; upgrade-insecure-requests
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   X-Frame-Options: DENY

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,22 @@
+# Security headers for Cloudflare Pages.
+# https://developers.cloudflare.com/pages/configuration/headers/
+# This file is copied verbatim into dist/ at build time and applied by the
+# Cloudflare Pages edge. (Note: it is NOT applied by `astro preview`, and Vercel
+# previews ignore it — Vercel uses vercel.json.)
+#
+# The Content-Security-Policy below is tailored to exactly what the site loads:
+#   - default-src 'self'              everything same-origin unless listed
+#   - img-src ... res.cloudinary.com  the fixed background photo (favicon/og are same-origin)
+#   - style-src 'unsafe-inline'       Astro inlines scoped <style>, plus the honeypot style="" attr
+#   - script-src 'self'               no runtime JS; the JSON-LD block is non-executable
+#   - form-action ... formspree.io    the contact form POSTs to Formspree
+# If you add an analytics script, web font, or other origin, widen the matching
+# directive or the browser will block it.
+
+/*
+  Content-Security-Policy: default-src 'self'; img-src 'self' https://res.cloudinary.com; style-src 'self' 'unsafe-inline'; script-src 'self'; font-src 'self'; form-action https://formspree.io; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; upgrade-insecure-requests
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  X-Frame-Options: DENY
+  Permissions-Policy: accelerometer=(), autoplay=(), camera=(), display-capture=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()
+  Strict-Transport-Security: max-age=31536000

--- a/tests/test.spec.js
+++ b/tests/test.spec.js
@@ -110,14 +110,57 @@ test("home page has og:image with alt and dimensions", async ({ page }) => {
 // if the browser reports any violation — i.e. if the site ever loads a resource
 // the policy doesn't allow (a new third-party script, font, image host, etc.),
 // CI goes red at PR time instead of the site silently breaking in production.
-function readCsp() {
-  const headersPath = fileURLToPath(new URL("../public/_headers", import.meta.url));
-  const text = readFileSync(headersPath, "utf8");
-  const match = text.match(/^\s*Content-Security-Policy:\s*(.+)$/m);
-  if (!match) throw new Error("Content-Security-Policy not found in public/_headers");
-  return match[1].trim();
+// Parse the `/*` rule of public/_headers into a { header: value } map.
+function parseCloudflareHeaders() {
+  const text = readFileSync(fileURLToPath(new URL("../public/_headers", import.meta.url)), "utf8");
+  const map = {};
+  let inRule = false;
+  for (const line of text.split("\n")) {
+    if (line.startsWith("/")) {
+      inRule = true;
+      continue;
+    }
+    if (!inRule) continue;
+    const m = line.match(/^\s+([A-Za-z-]+):\s*(.+)$/);
+    if (m) map[m[1]] = m[2].trim();
+  }
+  return map;
 }
-const csp = readCsp();
+
+// Flatten vercel.json's headers config into the same { header: value } map.
+function parseVercelHeaders() {
+  const json = JSON.parse(
+    readFileSync(fileURLToPath(new URL("../vercel.json", import.meta.url)), "utf8"),
+  );
+  const map = {};
+  for (const rule of json.headers ?? []) {
+    for (const h of rule.headers ?? []) map[h.key] = h.value.trim();
+  }
+  return map;
+}
+
+const cloudflareHeaders = parseCloudflareHeaders();
+const csp = cloudflareHeaders["Content-Security-Policy"];
+
+// Cloudflare (_headers) and Vercel (vercel.json) are separate files; keep them
+// in lockstep so a header changed in one host isn't forgotten in the other.
+test("vercel.json security headers match public/_headers", () => {
+  const vercelHeaders = parseVercelHeaders();
+  const securityHeaders = [
+    "Content-Security-Policy",
+    "X-Content-Type-Options",
+    "Referrer-Policy",
+    "X-Frame-Options",
+    "Permissions-Policy",
+    "Strict-Transport-Security",
+  ];
+  for (const key of securityHeaders) {
+    expect(cloudflareHeaders[key], `${key} present in public/_headers`).toBeTruthy();
+    expect(vercelHeaders[key], `${key} in vercel.json matches public/_headers`).toBe(
+      cloudflareHeaders[key],
+    );
+  }
+});
 
 for (const path of ["/", "/contact"]) {
   test(`no CSP violations on ${path}`, async ({ page }) => {

--- a/tests/test.spec.js
+++ b/tests/test.spec.js
@@ -1,4 +1,6 @@
 import { expect, test } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 // --- Structural assertions (primary gate, deterministic) ---
 
@@ -101,3 +103,42 @@ test("home page has og:image with alt and dimensions", async ({ page }) => {
     /buckley/i,
   );
 });
+
+// --- CSP drift guard ---
+// Read the real policy from public/_headers so this test always reflects what
+// ships. Load each page with that CSP applied to the document response and fail
+// if the browser reports any violation — i.e. if the site ever loads a resource
+// the policy doesn't allow (a new third-party script, font, image host, etc.),
+// CI goes red at PR time instead of the site silently breaking in production.
+function readCsp() {
+  const headersPath = fileURLToPath(new URL("../public/_headers", import.meta.url));
+  const text = readFileSync(headersPath, "utf8");
+  const match = text.match(/^\s*Content-Security-Policy:\s*(.+)$/m);
+  if (!match) throw new Error("Content-Security-Policy not found in public/_headers");
+  return match[1].trim();
+}
+const csp = readCsp();
+
+for (const path of ["/", "/contact"]) {
+  test(`no CSP violations on ${path}`, async ({ page }) => {
+    const violations = [];
+    page.on("console", (msg) => {
+      if (/Content Security Policy/i.test(msg.text())) violations.push(msg.text());
+    });
+    // Apply the real CSP to the navigated document; let subresources load normally.
+    await page.route("**/*", async (route) => {
+      if (route.request().resourceType() === "document") {
+        const res = await route.fetch();
+        await route.fulfill({
+          response: res,
+          headers: { ...res.headers(), "content-security-policy": csp },
+        });
+      } else {
+        await route.continue();
+      }
+    });
+    await page.goto(path, { waitUntil: "domcontentloaded" });
+    await page.waitForTimeout(500);
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; img-src 'self' https: data:; style-src 'self' 'unsafe-inline' https:; script-src 'self'; font-src 'self' https: data:; connect-src 'self'; form-action 'self' https://formspree.io; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; upgrade-insecure-requests"
+        },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        {
+          "key": "Permissions-Policy",
+          "value": "accelerometer=(), autoplay=(), camera=(), display-capture=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()"
+        },
+        { "key": "Strict-Transport-Security", "value": "max-age=31536000" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Security response headers for **both** hosts, a CSP designed not to break as the site grows, and two drift guards.

> **Stacked on #462.** This PR targets the `claude/fix-prettier-config` branch so its diff is security-only. The formatting/config fix lives in **#462** and should merge first; GitHub will retarget this PR to `master` automatically once #462 merges.

### Security headers — Cloudflare + Vercel
- **`public/_headers`** (Cloudflare Pages) and **`vercel.json`** (Vercel) carry the same set: `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `X-Frame-Options: DENY`, a restrictive `Permissions-Policy`, conservative `HSTS`, and a **Content-Security-Policy**.
- The CSP is **forward-compatible** (pages + JS frameworks are planned):
  - `script-src 'self'` stays strict — the real XSS surface. Astro bundles React/Svelte/etc. islands as same-origin module scripts, so `'self'` covers them; a *third-party* script would need its origin added (the guard below catches that).
  - `img-src`/`style-src`/`font-src` allow `https:`/`data:` so new images, web fonts, and inline styles don't silently break.
  - `connect-src 'self'`, `form-action 'self' https://formspree.io`, plus `frame-ancestors`/`base-uri`/`object-src` lockdowns.

### Drift guards (Playwright)
- **CSP guard** — applies the real policy from `_headers` to each page and fails if the browser reports any violation. *Verified it fails on a real violation.*
- **Host parity guard** — asserts `vercel.json` and `public/_headers` carry identical security headers. *Verified it fails on a deliberate drift.*

## Verification

- `astro check` → 0 / 0 / 0
- `prettier --check .` → clean
- `astro build` → `dist/_headers` emitted; `vercel.json` at root
- Playwright → 18/18 (15 prior + CSP guard ×2 + host-parity); both guards confirmed to fail on real drift

## Notes

- **HSTS** is conservative (`max-age=31536000`, no `includeSubDomains`/`preload`) — strengthen once every `*.buckley.ca` subdomain is confirmed HTTPS-only.
- Couldn't live-verify headers on the previews (the agent proxy blocks outbound to `pages.dev`/`vercel.app`); validated by auditing built resources + the automated guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)