### PR TITLE
Redesign 404 with reusable compass component (closes #148)

### DIFF
--- a/src/components/Compass.astro
+++ b/src/components/Compass.astro
@@ -1,0 +1,137 @@
+---
+interface Props {
+  /** CSS length for the rendered width/height. Defaults to 10rem. */
+  size?: string;
+  /** Accessible label. Set to "" together with `decorative` to hide from a11y tree. */
+  label?: string;
+  /** Render as decorative (aria-hidden) instead of an img with a label. */
+  decorative?: boolean;
+  /** Extra class(es) merged onto the root <svg>. */
+  class?: string;
+}
+
+const {
+  size = "10rem",
+  label = "A compass, to help you find your way",
+  decorative = false,
+  class: className,
+} = Astro.props;
+
+// Unique id prefix so several compasses on one page don't share gradient ids.
+const uid = "compass-" + Math.random().toString(36).slice(2, 8);
+---
+
+<svg
+  class:list={["compass", className]}
+  style={`width:${size};height:${size};`}
+  viewBox="0 0 240 240"
+  xmlns="http://www.w3.org/2000/svg"
+  role={decorative ? undefined : "img"}
+  aria-hidden={decorative ? "true" : undefined}
+  aria-label={decorative ? undefined : label}
+>
+  <defs>
+    <radialGradient id={`${uid}-bezel`} cx="42%" cy="38%" r="68%">
+      <stop offset="0%" stop-color="#ececec"></stop>
+      <stop offset="55%" stop-color="#a9a9a9"></stop>
+      <stop offset="100%" stop-color="#555555"></stop>
+    </radialGradient>
+    <radialGradient id={`${uid}-hub`} cx="40%" cy="36%" r="70%">
+      <stop offset="0%" stop-color="#f5f5f5"></stop>
+      <stop offset="100%" stop-color="#777777"></stop>
+    </radialGradient>
+    <radialGradient id={`${uid}-face`} cx="44%" cy="40%" r="72%">
+      <stop offset="0%" stop-color="#fbfbfb"></stop>
+      <stop offset="70%" stop-color="#eeeeee"></stop>
+      <stop offset="100%" stop-color="#dadada"></stop>
+    </radialGradient>
+
+    <!-- One major (cardinal) star point, pointing north -->
+    <g id={`${uid}-major`}>
+      <polygon class="rose-dk" points="120,54 112,112 120,120"></polygon>
+      <polygon class="rose-lt" points="120,54 128,112 120,120"></polygon>
+    </g>
+    <!-- One minor (intercardinal) star point, pointing north -->
+    <g id={`${uid}-minor`}>
+      <polygon class="rose-dk" points="120,70 114,114 120,120"></polygon>
+      <polygon class="rose-lt" points="120,70 126,114 120,120"></polygon>
+    </g>
+  </defs>
+
+  <!-- Case -->
+  <circle cx="120" cy="120" r="110" fill={`url(#${uid}-bezel)`} stroke="#333" stroke-width="0.5"
+  ></circle>
+  <circle cx="120" cy="120" r="98" fill="none" stroke="#fff" stroke-width="1.5" opacity="0.6"
+  ></circle>
+  <circle cx="120" cy="120" r="93" fill="none" stroke="#333" stroke-width="3"></circle>
+
+  <!-- Dial face -->
+  <circle cx="120" cy="120" r="90" fill={`url(#${uid}-face)`} stroke="#666" stroke-width="1.5"
+  ></circle>
+  <!-- Degree ticks, with gaps left at the four cardinal letters -->
+  <g
+    class="ticks"
+    fill="none"
+    stroke="#555"
+    stroke-width="6"
+    stroke-dasharray="1 7.3"
+    opacity="0.5"
+  >
+    <path d="M202.7 134.6 A84 84 0 0 1 134.6 202.7"></path>
+    <path d="M105.4 202.7 A84 84 0 0 1 37.3 134.6"></path>
+    <path d="M37.3 105.4 A84 84 0 0 1 105.4 37.3"></path>
+    <path d="M134.6 37.3 A84 84 0 0 1 202.7 105.4"></path>
+  </g>
+
+  <!-- Compass rose -->
+  <g class="rose">
+    <use href={`#${uid}-minor`} transform="rotate(45 120 120)"></use>
+    <use href={`#${uid}-minor`} transform="rotate(135 120 120)"></use>
+    <use href={`#${uid}-minor`} transform="rotate(225 120 120)"></use>
+    <use href={`#${uid}-minor`} transform="rotate(315 120 120)"></use>
+    <use href={`#${uid}-major`}></use>
+    <use href={`#${uid}-major`} transform="rotate(90 120 120)"></use>
+    <use href={`#${uid}-major`} transform="rotate(180 120 120)"></use>
+    <use href={`#${uid}-major`} transform="rotate(270 120 120)"></use>
+  </g>
+
+  <!-- Cardinal letters -->
+  <g class="dir">
+    <text x="120" y="40" text-anchor="middle" dominant-baseline="middle">N</text>
+    <text x="120" y="200" text-anchor="middle" dominant-baseline="middle">S</text>
+    <text x="200" y="120" text-anchor="middle" dominant-baseline="middle">E</text>
+    <text x="40" y="120" text-anchor="middle" dominant-baseline="middle">W</text>
+  </g>
+
+  <!-- Needle -->
+  <polygon points="120,52 126,120 114,120" fill="#333"></polygon>
+  <polygon points="120,188 126,120 114,120" fill="#bbb"></polygon>
+
+  <!-- Hub -->
+  <circle cx="120" cy="120" r="10" fill={`url(#${uid}-hub)`} stroke="#333" stroke-width="1.5"
+  ></circle>
+  <circle cx="120" cy="120" r="3.5" fill="#444"></circle>
+</svg>
+
+<style>
+  .rose-dk {
+    fill: #333;
+  }
+
+  .rose-lt {
+    fill: #cfcfcf;
+  }
+
+  .rose-dk,
+  .rose-lt {
+    stroke: #222;
+    stroke-width: 0.4;
+  }
+
+  .dir text {
+    fill: #2a2a2a;
+    font-size: 16px;
+    font-weight: 700;
+    font-family: Georgia, "Times New Roman", serif;
+  }
+</style>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,39 +1,14 @@
 ---
 import Layout from "../layouts/Layout.astro";
+import Compass from "../components/Compass.astro";
 ---
 
 <Layout title="Buckley.ca - Not Found" description="The page you're looking for couldn't be found.">
   <section class="center">
     <div class="box">
-      <svg
-        class="compass"
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 200 200"
-        role="img"
-        aria-label="A compass, to help you find your way"
-      >
-        <circle class="ring" cx="100" cy="100" r="80"></circle>
-        <circle class="ring ring--inner" cx="100" cy="100" r="66"></circle>
-
-        <!-- Cardinal ticks, set in the gap between the two rings -->
-        <g class="ticks">
-          <line x1="100" y1="22" x2="100" y2="30"></line>
-          <line x1="100" y1="170" x2="100" y2="178"></line>
-          <line x1="22" y1="100" x2="30" y2="100"></line>
-          <line x1="170" y1="100" x2="178" y2="100"></line>
-        </g>
-
-        <!-- Needle -->
-        <polygon class="needle needle--n" points="100,62 110,100 100,106 90,100"></polygon>
-        <polygon class="needle needle--s" points="100,138 110,100 100,94 90,100"></polygon>
-        <circle class="hub" cx="100" cy="100" r="6"></circle>
-
-        <!-- Cardinal letters, inside the rings so nothing clips them -->
-        <text class="dir" x="100" y="51" text-anchor="middle" dominant-baseline="middle">N</text>
-        <text class="dir" x="100" y="149" text-anchor="middle" dominant-baseline="middle">S</text>
-        <text class="dir" x="149" y="100" text-anchor="middle" dominant-baseline="middle">E</text>
-        <text class="dir" x="51" y="100" text-anchor="middle" dominant-baseline="middle">W</text>
-      </svg>
+      <div class="compass-wrap">
+        <Compass />
+      </div>
 
       <h1>404 | Page not found</h1>
       <p>
@@ -66,49 +41,8 @@ import Layout from "../layouts/Layout.astro";
     border-radius: 10px;
   }
 
-  .compass {
-    width: 9rem;
-    height: 9rem;
+  .compass-wrap {
     margin-bottom: 0.5rem;
-  }
-
-  .ring {
-    fill: none;
-    stroke: #333;
-    stroke-width: 3;
-  }
-
-  .ring--inner {
-    stroke-width: 1.5;
-    opacity: 0.4;
-  }
-
-  .ticks line {
-    stroke: #333;
-    stroke-width: 3;
-    stroke-linecap: round;
-    opacity: 0.6;
-  }
-
-  .needle--n {
-    fill: #333;
-  }
-
-  .needle--s {
-    fill: #bbb;
-  }
-
-  .hub {
-    fill: #fff;
-    stroke: #333;
-    stroke-width: 2;
-  }
-
-  .dir {
-    fill: #333;
-    font-size: 16px;
-    font-weight: 700;
-    font-family: inherit;
   }
 
   h1 {


### PR DESCRIPTION
## What

Redesigns the 404 page and extracts the compass into a reusable component.

### Changes
- **New `<Compass />` component** ([src/components/Compass.astro](src/components/Compass.astro)) — a detailed monochrome compass (ornate rose, serif cardinal letters, gapped tick ring, clean hairline rim). Props: `size`, `label`, `decorative` (renders `aria-hidden`), and `class`. Gradient/`<use>` ids are namespaced per instance, so multiple compasses can coexist on one page.
- **404 page** ([src/pages/404.astro](src/pages/404.astro)) now imports `<Compass />` and keeps only layout/copy/buttons. Greyscale palette on the site's existing photo background + translucent box. Plain, non-nautical copy with Home/Contact links.

### Verification
- `npm run build` passes; `/404.html` generates cleanly.
- `prettier --check` passes.

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)