### PR TITLE
ci: bump checkout and setup-node to v5 for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: ".node-version"
           cache: "npm"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Dependency Review"
         uses: actions/dependency-review-action@v4


### PR DESCRIPTION
## What
Bump `actions/checkout` and `actions/setup-node` from v4 to v5 across CI workflows.

## Why
`actions/checkout@v4` and `actions/setup-node@v4` run on the deprecated Node.js 20 runtime — GitHub is currently forcing them onto Node 24 and emitting a deprecation warning ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). v5 targets Node 24 natively and clears the warning.

## Changes
- `.github/workflows/ci.yml`: `checkout@v4 → v5`, `setup-node@v4 → v5`
- `.github/workflows/dependency-review.yml`: `checkout@v4 → v5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)