### PR TITLE
chore: approve esbuild and sharp install scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,9 @@
   "engines": {
     "node": ">=24.0.0"
   },
-  "packageManager": "npm@11.17.0"
+  "packageManager": "npm@11.17.0",
+  "allowScripts": {
+    "esbuild@0.28.1": true,
+    "sharp@0.34.5": true
+  }
 }


### PR DESCRIPTION
## Summary

Adds an `allowScripts` allowlist to `package.json` approving the install/build scripts for `esbuild` and `sharp`, so the approval is shared across all environments (CI, Vercel, Cloudflare, and other developers) instead of prompting per-machine.

## Changes

- `package.json`: add `allowScripts` entry for `esbuild@0.28.1` and `sharp@0.34.5`.

These are legitimate native-dependency build scripts:
- `esbuild@0.28.1` — `postinstall: node install.js`
- `sharp@0.34.5` — `install: node install/check.js || npm run build`

## Verification

- `npm i` completes without the pending-scripts warning and reports 0 vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016av9URv1DkubSF7z1jexNe

---
_Generated by [Claude Code](https://claude.ai/code/session_016av9URv1DkubSF7z1jexNe)_