### PR TITLE
Bump js-yaml 4.3.0 → 4.3.1 (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3609,9 +3609,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Fixes Dependabot alert #74.

## What

Lockfile-only bump of `js-yaml` from 4.3.0 to 4.3.1. It's a transitive dev dependency (`astro 7.1.6 → js-yaml ^4.3.0`), and 4.3.1 already satisfies that range, so `package.json` is untouched and no other package moved.

```
-      "version": "4.3.0",
+      "version": "4.3.1",
```

## Why

`resolveYamlOmap()` in js-yaml 4.x enforced key uniqueness for `!!omap` sequences with a linear `objectKeys.indexOf(...)` scan inside the per-element loop, making resolution O(n²) in the number of entries. Since `!!omap` is in the default schema, a plain `yaml.load()` on a modestly sized document blocks the event loop for its whole duration. Same weakness as CVE-2026-59870 in the 5.x line; 4.3.1 is the backport.

4.3.1 replaces the scan with an own-property lookup on an accumulator object, so key checks are O(1).

## Verification

Proof of concept from the advisory, run against the installed 4.3.1:

```
n=10000 load=106ms
n=20000 load=120ms
n=40000 load=212ms
n=80000 load=408ms
```

Runtime roughly doubles per doubling of `n` (linear), versus the ~4× per doubling reported for 4.3.0. Duplicate-key rejection still works — `!!omap` with a repeated key is still rejected.

Project checks, all clean:

- `npm run check` — 0 errors, 0 warnings, 0 hints (13 files)
- `npm run lint` — Prettier clean
- `npm run build` — 3 pages built, sitemap flattened
- `npm test` — 18/18 Playwright tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3w8zyCQEsR8aZtoC2CAoF)_